### PR TITLE
feat: Add AgentState class to represent agent memory

### DIFF
--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -1,0 +1,82 @@
+package chemotaxis.g1;
+
+public class AgentState {
+    // State is represented as a single byte of memory
+    private byte state;
+
+    private static final byte NORTH_BITS = 0x0;
+    private static final byte EAST_BITS = 0x01;
+    private static final byte SOUTH_BITS = 0x02;
+    private static final byte WEST_BITS = 0x3;
+
+    // First two bits are used for direction
+    private static final byte DIRECTION_MASK = 0x3;
+
+    public enum Direction {
+        NORTH,
+        EAST,
+        SOUTH,
+        WEST
+    }
+
+    public AgentState() {
+        this.state = 0x0;
+    }
+
+    /**
+     * Initialize the agent with a prior serialized state
+     *
+     * @param prior_state Byte serialization of the agent's prior state
+     */
+    public AgentState(Byte prior_state) {
+        this.state = prior_state;
+    }
+
+    public Byte serialize() {
+        return this.state;
+    }
+
+    /**
+     * setDirection - Set the direction the agent just moved
+     *
+     * @param dir Direction the agent just moved
+     */
+    public void setDirection(Direction dir) {
+        this.state &= ~DIRECTION_MASK;
+        switch (dir) {
+            case NORTH:
+                this.state &= NORTH_BITS;
+                break;
+            case EAST:
+                this.state &= EAST_BITS;
+                break;
+            case WEST:
+                this.state &= WEST_BITS;
+                break;
+            case SOUTH:
+                this.state &= SOUTH_BITS;
+                break;
+            default:
+                throw new RuntimeException("invalid Direction enum");
+        }
+    }
+
+    /**
+     * getDirection - Retrieve the previous direction the agent moved
+     *
+     * @return The previous direction the agent moved
+     */
+    public Direction getDirection() {
+        switch (this.state & DIRECTION_MASK) {
+            case NORTH_BITS:
+                return Direction.NORTH;
+            case EAST_BITS:
+                return Direction.EAST;
+            case WEST_BITS:
+                return Direction.WEST;
+            case SOUTH_BITS:
+                return Direction.SOUTH;
+        }
+        throw new RuntimeException("unreachable direction state");
+    }
+}

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -31,6 +31,22 @@ public class AgentState {
         return this.state;
     }
 
+    public CardinalDirection asCardinalDir(DirectionType dir) {
+        switch (dir) {
+            case NORTH:
+                return CardinalDirection.NORTH;
+            case SOUTH:
+                return CardinalDirection.SOUTH;
+            case EAST:
+                return CardinalDirection.EAST;
+            case WEST:
+                return CardinalDirection.WEST;
+            case CURRENT:
+                return this.getDirection();
+        }
+        throw new RuntimeException("unreachable");
+    }
+
     /**
      * setDirection - Set the direction the agent just moved
      *
@@ -40,7 +56,10 @@ public class AgentState {
         if (dir == DirectionType.CURRENT) {
             return;
         }
+        setDirection(this.asCardinalDir(dir));
+    }
 
+    public void setDirection(CardinalDirection dir) {
         this.state &= ~DIRECTION_MASK;
         switch (dir) {
             case NORTH:
@@ -65,17 +84,18 @@ public class AgentState {
      *
      * @return The previous direction the agent moved
      */
-    public DirectionType getDirection() {
+    public CardinalDirection getDirection() {
         switch (this.state & DIRECTION_MASK) {
             case NORTH_BITS:
-                return DirectionType.NORTH;
+                return CardinalDirection.NORTH;
             case EAST_BITS:
-                return DirectionType.EAST;
+                return CardinalDirection.EAST;
             case WEST_BITS:
-                return DirectionType.WEST;
+                return CardinalDirection.WEST;
             case SOUTH_BITS:
-                return DirectionType.SOUTH;
+                return CardinalDirection.SOUTH;
         }
         throw new RuntimeException("unreachable direction state");
     }
+
 }

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -1,5 +1,7 @@
 package chemotaxis.g1;
 
+import chemotaxis.sim.DirectionType;
+
 public class AgentState {
     // State is represented as a single byte of memory
     private byte state;
@@ -11,13 +13,6 @@ public class AgentState {
 
     // First two bits are used for direction
     private static final byte DIRECTION_MASK = 0x3;
-
-    public enum Direction {
-        NORTH,
-        EAST,
-        SOUTH,
-        WEST
-    }
 
     public AgentState() {
         this.state = 0x0;
@@ -41,7 +36,11 @@ public class AgentState {
      *
      * @param dir Direction the agent just moved
      */
-    public void setDirection(Direction dir) {
+    public void setDirection(DirectionType dir) {
+        if (dir == DirectionType.CURRENT) {
+            return;
+        }
+
         this.state &= ~DIRECTION_MASK;
         switch (dir) {
             case NORTH:
@@ -66,16 +65,16 @@ public class AgentState {
      *
      * @return The previous direction the agent moved
      */
-    public Direction getDirection() {
+    public DirectionType getDirection() {
         switch (this.state & DIRECTION_MASK) {
             case NORTH_BITS:
-                return Direction.NORTH;
+                return DirectionType.NORTH;
             case EAST_BITS:
-                return Direction.EAST;
+                return DirectionType.EAST;
             case WEST_BITS:
-                return Direction.WEST;
+                return DirectionType.WEST;
             case SOUTH_BITS:
-                return Direction.SOUTH;
+                return DirectionType.SOUTH;
         }
         throw new RuntimeException("unreachable direction state");
     }

--- a/src/chemotaxis/g1/CardinalDirection.java
+++ b/src/chemotaxis/g1/CardinalDirection.java
@@ -1,0 +1,60 @@
+package chemotaxis.g1;
+
+import chemotaxis.sim.DirectionType;
+
+/**
+ * Direction enum that does NOT include "current" as a valid direction.
+ * This makes operations on directions such as "turn right" type safe.
+ */
+public enum CardinalDirection {
+    NORTH,
+    SOUTH,
+    EAST,
+    WEST;
+
+    public DirectionType asDirectionType() {
+        switch (this) {
+            case NORTH:
+                return DirectionType.NORTH;
+            case SOUTH:
+                return DirectionType.SOUTH;
+            case EAST:
+                return DirectionType.EAST;
+            case WEST:
+                return DirectionType.WEST;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection reverseOf() {
+        switch (this) {
+            case NORTH:
+                return CardinalDirection.SOUTH;
+            case SOUTH:
+                return CardinalDirection.NORTH;
+            case EAST:
+                return CardinalDirection.WEST;
+            case WEST:
+                return CardinalDirection.EAST;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection rightOf() {
+        switch (this) {
+            case NORTH:
+                return CardinalDirection.WEST;
+            case SOUTH:
+                return CardinalDirection.EAST;
+            case EAST:
+                return CardinalDirection.SOUTH;
+            case WEST:
+                return CardinalDirection.NORTH;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection leftOf() {
+        return this.rightOf().reverseOf();
+    }
+}


### PR DESCRIPTION
Adds a class `AgentState` with helper methods to update and query the agent state. This class represents the state as an 8-bit (byte) bitfield, so serialization to `Byte` is a simple boxing operation.

Currently 2 bits are used to store the previous direction of the agent (north, south, east, west). That leaves 6 bits that we can use to store other information.

The class is designed to be type safe, so ideally any additional data we store for the agent should have an enum type defined to enumerate the possible states and the `AgentState` class should encapsulate the logic to convert between the enum type and the bitfield representation.