### PR TITLE
Add wall handling routine & class for Agent State

### DIFF
--- a/src/chemotaxis/g1/Agent.java
+++ b/src/chemotaxis/g1/Agent.java
@@ -1,0 +1,90 @@
+package chemotaxis.g1;
+
+import java.util.Map;
+
+import chemotaxis.sim.DirectionType;
+import chemotaxis.sim.ChemicalCell;
+import chemotaxis.sim.ChemicalCell.ChemicalType;
+import chemotaxis.sim.Move;
+import chemotaxis.sim.SimPrinter;
+
+public class Agent extends chemotaxis.sim.Agent {
+
+    /**
+     * Agent constructor
+     *
+     * @param simPrinter simulation printer
+     */
+    public Agent(SimPrinter simPrinter) {
+        super(simPrinter);
+    }
+
+    /**
+     * Move agent
+     *
+     * @param randomNum     random number available for agents
+     * @param previousState byte of previous state
+     * @param currentCell   current cell
+     * @param neighborMap   map of cell's neighbors
+     * @return agent move
+     */
+    @Override
+    public Move makeMove(Integer randomNum, Byte previousState, ChemicalCell currentCell, Map<DirectionType, ChemicalCell> neighborMap) {
+        final AgentState prevState = new AgentState(previousState);
+        Move move = new Move();
+
+        ChemicalType chosenChemicalType = ChemicalType.BLUE;
+
+        double highestConcentration = currentCell.getConcentration(chosenChemicalType);
+        for (DirectionType directionType : neighborMap.keySet()) {
+            if (highestConcentration <= neighborMap.get(directionType).getConcentration(chosenChemicalType)) {
+                highestConcentration = neighborMap.get(directionType).getConcentration(chosenChemicalType);
+                move.directionType = directionType;
+            }
+        }
+        return move;
+    }
+
+    /**
+     * handleWall alters the agent's next direction to account for collisions with walls.
+     * <p>
+     * This routine should be called after the agent has selected its next direction.
+     * If moving in the selected direction is impossible since the square is blocked,
+     * this routine alters the direction according to the following rules:
+     * <p>
+     * 1. If possible, turn right of the currently selected direction (i.e. if the agent wants
+     * to move south, try to move west instead).
+     * 2. If turning right is impossible, turn left.
+     * 3. If right and left are blocked, go in the opposite direction of the agent's selected
+     * direction.
+     * <p>
+     * Importantly, the agent's state is NOT updated to reflect the newly chosen direction. This
+     * means that barring external stimuli, the agent will resume moving in its previously desired
+     * direction as soon as it becomes unblocked.
+     * <p>
+     * For example, imagine the agent wanted to move south, was blocked, and moved right instead.
+     * On its next turn, if south is unblocked, the agent's default action will be to move south.
+     *
+     * @param nextMove    Desired next move corresponding AgentState as a byte.
+     * @param neighborMap Map of agent's immediate surroundings.
+     * @param prevState   Agent's previous state. Used to decode "current" to a cardinal direction
+     * @return
+     */
+    private Move handleWall(Move nextMove, final Map<DirectionType, ChemicalCell> neighborMap, final AgentState prevState) {
+        CardinalDirection nextDirection = prevState.asCardinalDir(nextMove.directionType);
+
+        if (neighborMap.get(nextDirection.asDirectionType()).isBlocked()) {
+            // Try right first, then left, then reverse
+            DirectionType right = nextDirection.rightOf().asDirectionType();
+            DirectionType left = nextDirection.leftOf().asDirectionType();
+            if (neighborMap.get(right).isOpen()) {
+                nextMove.directionType = right;
+            } else if (neighborMap.get(left).isOpen()) {
+                nextMove.directionType = left;
+            } else {
+                nextMove.directionType = nextDirection.reverseOf().asDirectionType();
+            }
+        }
+        return nextMove;
+    }
+}

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -1,0 +1,82 @@
+package chemotaxis.g1;
+
+public class AgentState {
+    // State is represented as a single byte of memory
+    private byte state;
+
+    private static final byte NORTH_BITS = 0x0;
+    private static final byte EAST_BITS = 0x01;
+    private static final byte SOUTH_BITS = 0x02;
+    private static final byte WEST_BITS = 0x3;
+
+    // First two bits are used for direction
+    private static final byte DIRECTION_MASK = 0x3;
+
+    public enum Direction {
+        NORTH,
+        EAST,
+        SOUTH,
+        WEST
+    }
+
+    public AgentState() {
+        this.state = 0x0;
+    }
+
+    /**
+     * Initialize the agent with a prior serialized state
+     *
+     * @param prior_state Byte serialization of the agent's prior state
+     */
+    public AgentState(Byte prior_state) {
+        this.state = prior_state;
+    }
+
+    public Byte serialize() {
+        return this.state;
+    }
+
+    /**
+     * setDirection - Set the direction the agent just moved
+     *
+     * @param dir Direction the agent just moved
+     */
+    public void setDirection(Direction dir) {
+        this.state &= ~DIRECTION_MASK;
+        switch (dir) {
+            case NORTH:
+                this.state &= NORTH_BITS;
+                break;
+            case EAST:
+                this.state &= EAST_BITS;
+                break;
+            case WEST:
+                this.state &= WEST_BITS;
+                break;
+            case SOUTH:
+                this.state &= SOUTH_BITS;
+                break;
+            default:
+                throw new RuntimeException("invalid Direction enum");
+        }
+    }
+
+    /**
+     * getDirection - Retrieve the previous direction the agent moved
+     *
+     * @return The previous direction the agent moved
+     */
+    public Direction getDirection() {
+        switch (this.state & DIRECTION_MASK) {
+            case NORTH_BITS:
+                return Direction.NORTH;
+            case EAST_BITS:
+                return Direction.EAST;
+            case WEST_BITS:
+                return Direction.WEST;
+            case SOUTH_BITS:
+                return Direction.SOUTH;
+        }
+        throw new RuntimeException("unreachable direction state");
+    }
+}

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -31,6 +31,22 @@ public class AgentState {
         return this.state;
     }
 
+    public CardinalDirection asCardinalDir(DirectionType dir) {
+        switch (dir) {
+            case NORTH:
+                return CardinalDirection.NORTH;
+            case SOUTH:
+                return CardinalDirection.SOUTH;
+            case EAST:
+                return CardinalDirection.EAST;
+            case WEST:
+                return CardinalDirection.WEST;
+            case CURRENT:
+                return this.getDirection();
+        }
+        throw new RuntimeException("unreachable");
+    }
+
     /**
      * setDirection - Set the direction the agent just moved
      *
@@ -40,7 +56,10 @@ public class AgentState {
         if (dir == DirectionType.CURRENT) {
             return;
         }
+        setDirection(this.asCardinalDir(dir));
+    }
 
+    public void setDirection(CardinalDirection dir) {
         this.state &= ~DIRECTION_MASK;
         switch (dir) {
             case NORTH:
@@ -65,17 +84,18 @@ public class AgentState {
      *
      * @return The previous direction the agent moved
      */
-    public DirectionType getDirection() {
+    public CardinalDirection getDirection() {
         switch (this.state & DIRECTION_MASK) {
             case NORTH_BITS:
-                return DirectionType.NORTH;
+                return CardinalDirection.NORTH;
             case EAST_BITS:
-                return DirectionType.EAST;
+                return CardinalDirection.EAST;
             case WEST_BITS:
-                return DirectionType.WEST;
+                return CardinalDirection.WEST;
             case SOUTH_BITS:
-                return DirectionType.SOUTH;
+                return CardinalDirection.SOUTH;
         }
         throw new RuntimeException("unreachable direction state");
     }
+
 }

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -1,5 +1,7 @@
 package chemotaxis.g1;
 
+import chemotaxis.sim.DirectionType;
+
 public class AgentState {
     // State is represented as a single byte of memory
     private byte state;
@@ -11,13 +13,6 @@ public class AgentState {
 
     // First two bits are used for direction
     private static final byte DIRECTION_MASK = 0x3;
-
-    public enum Direction {
-        NORTH,
-        EAST,
-        SOUTH,
-        WEST
-    }
 
     public AgentState() {
         this.state = 0x0;
@@ -41,7 +36,11 @@ public class AgentState {
      *
      * @param dir Direction the agent just moved
      */
-    public void setDirection(Direction dir) {
+    public void setDirection(DirectionType dir) {
+        if (dir == DirectionType.CURRENT) {
+            return;
+        }
+
         this.state &= ~DIRECTION_MASK;
         switch (dir) {
             case NORTH:
@@ -66,16 +65,16 @@ public class AgentState {
      *
      * @return The previous direction the agent moved
      */
-    public Direction getDirection() {
+    public DirectionType getDirection() {
         switch (this.state & DIRECTION_MASK) {
             case NORTH_BITS:
-                return Direction.NORTH;
+                return DirectionType.NORTH;
             case EAST_BITS:
-                return Direction.EAST;
+                return DirectionType.EAST;
             case WEST_BITS:
-                return Direction.WEST;
+                return DirectionType.WEST;
             case SOUTH_BITS:
-                return Direction.SOUTH;
+                return DirectionType.SOUTH;
         }
         throw new RuntimeException("unreachable direction state");
     }

--- a/src/chemotaxis/g1/CardinalDirection.java
+++ b/src/chemotaxis/g1/CardinalDirection.java
@@ -1,0 +1,60 @@
+package chemotaxis.g1;
+
+import chemotaxis.sim.DirectionType;
+
+/**
+ * Direction enum that does NOT include "current" as a valid direction.
+ * This makes operations on directions such as "turn right" type safe.
+ */
+public enum CardinalDirection {
+    NORTH,
+    SOUTH,
+    EAST,
+    WEST;
+
+    public DirectionType asDirectionType() {
+        switch (this) {
+            case NORTH:
+                return DirectionType.NORTH;
+            case SOUTH:
+                return DirectionType.SOUTH;
+            case EAST:
+                return DirectionType.EAST;
+            case WEST:
+                return DirectionType.WEST;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection reverseOf() {
+        switch (this) {
+            case NORTH:
+                return CardinalDirection.SOUTH;
+            case SOUTH:
+                return CardinalDirection.NORTH;
+            case EAST:
+                return CardinalDirection.WEST;
+            case WEST:
+                return CardinalDirection.EAST;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection rightOf() {
+        switch (this) {
+            case NORTH:
+                return CardinalDirection.WEST;
+            case SOUTH:
+                return CardinalDirection.EAST;
+            case EAST:
+                return CardinalDirection.SOUTH;
+            case WEST:
+                return CardinalDirection.NORTH;
+        }
+        throw new RuntimeException("unreachable");
+    }
+
+    public CardinalDirection leftOf() {
+        return this.rightOf().reverseOf();
+    }
+}


### PR DESCRIPTION
## AgentState class

Adds a class `AgentState` with helper methods to update and query the agent state. This class represents the state as an 8-bit (byte) bitfield, so serialization to `Byte` is a simple boxing operation.

Currently 2 bits are used to store the previous direction of the agent (north, south, east, west). That leaves 6 bits that we can use to store other information.

The class is designed to be type safe, so ideally any additional data we store for the agent should have an enum type defined to enumerate the possible states and the `AgentState` class should encapsulate the logic to convert between the enum type and the bitfield representation.


## Wall Handling
Adds a basic wall handling routine intended to be called after the agent
has made an "intelligent" decision about the direction it should move.
