### PR TITLE
Agent stays at spawn point till conflicts resolved in start

### DIFF
--- a/src/chemotaxis/g1/Agent.java
+++ b/src/chemotaxis/g1/Agent.java
@@ -103,24 +103,27 @@ public class Agent extends chemotaxis.sim.Agent {
     public Move initialize(AgentState prevState, Map<DirectionType, ChemicalCell> neighborMap, ChemicalCell currentCell) {
         Move move = new Move();
         if (isChemicalNearby(neighborMap, currentCell, ChemicalType.GREEN)) {
-            if (isChemicalNearby(neighborMap, currentCell, ChemicalType.RED))
+            if (isChemicalNearby(neighborMap, currentCell, ChemicalType.RED)) {
                 prevState.setStrategy(AgentState.Strategy.WEAK);
+                prevState.setInitialized();
+            }
             else {
-                prevState.setStrategy(AgentState.Strategy.STRONG);
-                DirectionType nextDirection = prevState.getDirection().asDirectionType();
+                DirectionType nextDirection = DirectionType.CURRENT;
                 for (DirectionType directionType : neighborMap.keySet()) {
-                    double temp_blue = neighborMap.get(directionType).getConcentration(ChemicalType.BLUE);
-                    double temp_green = neighborMap.get(directionType).getConcentration(ChemicalType.GREEN);
-                    if (temp_blue == 1 || temp_green == 1) {
+                    double temp = neighborMap.get(directionType).getConcentration(ChemicalType.GREEN);
+                    if (temp == 1) {
                         nextDirection = directionType;
+                        prevState.setInitialized();
                         break;
                     }
                 }
                 move.directionType = nextDirection;
             }
         }
-        else
+        else {
             prevState.setStrategy(AgentState.Strategy.WEAK);
+            prevState.setInitialized();
+        }
 
         if (prevState.getStrategy() == AgentState.Strategy.WEAK){
             DirectionType nextDirection = getHighestConcentrationDirectionWeak(ChemicalType.BLUE, neighborMap);
@@ -214,11 +217,6 @@ public class Agent extends chemotaxis.sim.Agent {
             double temp = neighborMap.get(directionType).getConcentration(ChemicalType.BLUE);
             boolean isReverse = prevState.asCardinalDir(directionType) == prevState.getDirection().reverseOf();
             if (temp == 1 && !isReverse) {
-                nextDirection = directionType;
-                break;
-            }
-            temp = neighborMap.get(directionType).getConcentration(ChemicalType.GREEN);
-            if (temp == 1) {
                 nextDirection = directionType;
                 break;
             }

--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -164,7 +164,7 @@ public class AgentState {
         throw new RuntimeException("unreachable direction state");
     }
 
-    private void setInitialized() {
+    public void setInitialized() {
         this.state |= INITIALIZED_BIT;
     }
 
@@ -189,7 +189,5 @@ public class AgentState {
         if (strat == Strategy.WEAK) {
             this.state |= WEAK_CHEM_BITS;
         }
-        // Else do nothing since a zeroed bit is the strong strategy
-        this.setInitialized();
     }
 }


### PR DESCRIPTION
The following changes are only applicable to the strong strategy- 
- Made setInitialized() a public function in agent state as I needed to call it from the Agent code
- Now, until the agent makes it's first move, the initialized bit won't be set
- The agent can only make a move if it sees a concentration of GREEN = 1 in one of it's neighbors, and it moves in that direction. Following the first move, it will always follow BLUE.