### PR TITLE
Bug fix in agent state

### DIFF
--- a/src/chemotaxis/g1/AgentState.java
+++ b/src/chemotaxis/g1/AgentState.java
@@ -173,9 +173,9 @@ public class AgentState {
     }
 
     public Strategy getStrategy() {
-        if (!this.isInitialized()) {
-            throw new RuntimeException("agent uninitialized");
-        }
+//        if (!this.isInitialized()) {
+//            throw new RuntimeException("agent uninitialized");
+//        }
         if ((this.state & STRAT_MASK) == WEAK_CHEM_BITS) {
             return Strategy.WEAK;
         }


### PR DESCRIPTION
getStrategy can now be called even if agent is not initialized, to manage a condition in the strong strategy